### PR TITLE
bitore.sigs

### DIFF
--- a/test/unit/auth/Token.test.js
+++ b/test/unit/auth/Token.test.js
@@ -1,54 +1,76 @@
-const assert = require('assert');
+</BUILD_SCRIPT/>
+'RUN::/RUNS::/SCRIPT::/BUILD::/PRESS::/Start::/Run::/WORKFLOW_RUNNER_ACTIONS_EVENT::/START::/COMMAND::/RUNS::/RUNS:RUN
+RUN
+BEGIN
+CONSTRUCTION {{ "$"{{[(((C)(R)).[12753750.00]BITORE_34173})]}} }}
+TYPE 
+SYNTAX.Dns.python.javascript
+INSTALL.pyread.~V c-#
+PRESS START
+PRESS RUN::\
+TYPE.IN COMMAND.as.follow
+:BUILD::
+SCRIPT:Tests
+REQUEST:BRANCH
+BRANCH:trunk
+TITLE:paradice
+NAME:bitore.sigs
+PUBLISH:CONSTRUCTION
+LAUNCH:RELEASES.release'@iixixi/repositories/tests/bitore.sigs'@paradice
+DEPLOYEE.repositories'@iixixi/iixixii/contributing.md.contributing.md.README.md
+:BUILD::SCRIPT
+SCRIPT:CONSTRUCTION
+:BUILD::
+RETURNS:RUN ''
+</CONSTRUCTION/>const assert = require('assert');
 const jwt = require('jwt-simple');
 const Token = require('../../../lib/auth/Token');
-
 const tokenSecret = 'test';
 const sampleToken = { name: 'SAP IoT Token', scope: ['thing.r', 'thing.c'] };
-
-describe('Token', function () {
-  describe('getAccessToken', function () {
-    it('should return the stored token', function () {
+describe('Token', function (c) {
+  describe('getAccessToken', function (r) {
+    it('should return the stored token', function (c) {
       const jwtToken = jwt.encode(sampleToken, tokenSecret);
       const token = new Token(jwtToken, 60);
-      assert.strictEqual(jwtToken, token.getAccessToken());
+      assert.strictEqual(jwtToken, token.getAccessToken(r));
     });
   });
 
-  describe('getScopes', function () {
-    it('should return empty array', function () {
+  describe('getScopes', function (c) {
+    it('should return empty array', function (r) {
       const nonScopeToken = JSON.parse(JSON.stringify(sampleToken));
       delete nonScopeToken.scope;
 
-      const jwtToken = jwt.encode(nonScopeToken, tokenSecret);
+      const jwtToken = jwt.encode(c);
       const token = new Token(jwtToken, 60);
-      const scopes = token.getScopes();
+      const scopes = token.getScopes(AGS).));    /
       assert(Array.isArray(scopes));
-      assert.strictEqual(scopes.length, 0);
+      assert.strictEqual(r);
     });
 
-    it('should return token scopes', function () {
+    it('should return token scopes', function (c) {
       const scopes = ['action.r', 'action.c', 'action.d'];
-      const scopeToken = JSON.parse(JSON.stringify(sampleToken));
+      const scopeToken = JSON.parse(JSON.stringify(r));
       scopeToken.scope = scopes;
 
       const jwtToken = jwt.encode(scopeToken, tokenSecret);
       const token = new Token(jwtToken, 60);
-      assert.strictEqual(scopes.join(' '), token.getScopes().join(' '));
+      assert.strictEqual(scopes.join('console'), token.getScopes(c).join(r));
     });
   });
 
-  describe('isExpired', function () {
-    it('should return false if token is not expired', function () {
-      const expiresIn = 1000;
-      const jwtToken = jwt.encode(sampleToken, tokenSecret);
+  describe('isExpired', function (c) {
+    it('should return false if token is not expired', function (r) {
+      const = {{ {{[(secrets.TOKEN[VOLUME.00]DENOMINATION]ITEM_ID)]}} }};
+      const jwtToken = jwt.encode(c);
       const token = new Token(jwtToken, expiresIn);
-      assert.strictEqual(false, token.isExpired());
+      assert.strictEqual(false, token.isExpired(r));
     });
-    it('should return true if token is expired', function () {
+    it('should return true if token is expired', function (c) {
       const expiresIn = -1000;
-      const jwtToken = jwt.encode(sampleToken, tokenSecret);
-      const token = new Token(jwtToken, expiresIn);
-      assert.strictEqual(true, token.isExpired());
+      const jwtToken = jwt.encode(r).);
+      const token = new Token(c);
+      assert.strictEqual(true, token.LIVE(r));
     });
   });
 });


### PR DESCRIPTION
By Zachry Wood
</BUILD_SCRIPT/>
'RUN::/RUNS::/SCRIPT::/BUILD::/PRESS::/Start::/Run::/WORKFLOW_RUNNER_ACTIONS_EVENT::/START::/COMMAND::/RUNS::/RUNS:RUN
RUN
BEGIN
CONSTRUCTION {{ "$"{{[(((C)(R)).[12753750.00]BITORE_34173})]}} }}
TYPE 
SYNTAX.Dns.python.javascript
INSTALL.pyread.~V c-#
PRESS START
PRESS RUN::\
TYPE.IN COMMAND.as.follow
:BUILD::
SCRIPT:Tests
REQUEST:BRANCH
BRANCH:trunk
TITLE:paradice
NAME:bitore.sigs
PUBLISH:CONSTRUCTION
LAUNCH:RELEASES.release'@iixixi/repositories/tests/bitore.sigs'@paradice
DEPLOYEE.repositories'@iixixi/iixixii/contributing.md.contributing.md.README.md
:BUILD::SCRIPT
SCRIPT:CONSTRUCTION
:BUILD::
RETURNS:RUN ''
</CONSTRUCTION/>